### PR TITLE
support developerPayload

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The result of this operation will be delivered to your updates observer
 
     private fun startFlowWithClient() {
            disposable.add(rxBilling.launchFlow(this, BillingFlowParams.newBuilder()
-                   .setSku("you_id")
+                   .setSkuDetails(SkuDetails) // see ## Load sku details
                    .setType(BillingClient.SkuType.SUBS)
                    .build())
                    .subscribe({

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         compileSdkVersion compileSdkVer
         versionCode rootProject.extensions.getByName("ext")["versionCode"]
         versionName rootProject.extensions.getByName("ext")["versionName"]
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.ext.junit.runners.AndroidJUnit4"
     }
     buildTypes {
         release {
@@ -45,5 +45,7 @@ dependencies {
     testImplementation testDependencies.jUnit
     testImplementation testDependencies.mockito
     testImplementation testDependencies.mockitoKotlin
-
+    androidTestImplementation testDependencies.runner
+    androidTestImplementation testDependencies.rules
+    androidTestImplementation testDependencies.ext
 }

--- a/app/src/androidTest/java/com/gen/rxbilling/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/gen/rxbilling/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.gen.rxbilling
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.gen.rxbilling", appContext.packageName)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,17 @@ apply from: 'dependencies.gradle'
 apply plugin: "com.hellofresh.gradle.deblibs"
 
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.3.50'
     ext.maven_version = '2.1'
     ext.bintray_version = '1.8.4'
-    ext.dokka_version = '0.9.16'
+    ext.dokka_version = '0.9.18'
     repositories {
         maven { url 'https://plugins.gradle.org/m2/' }
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:$maven_version"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintray_version"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,23 +7,27 @@ ext {
     versionName = '2.0.0'
 
     // Kotlin
-    kotlinVer = '1.3.40'
+    kotlinVer = '1.3.50'
     androidKtxVer = '1.0.2'
 
     // Support library
     constraintLayout = '1.1.3'
 
     // AndroidX
-    xAppCompatVer = '1.1.0-alpha05'
+    xAppCompatVer = '1.1.0-rc01'
     xLifecycleVer = '2.0.0'
-    xFragmentVer = '1.1.0-alpha08'
+    xFragmentVer = '1.1.0-rc04'
+    xRulesVer = '1.1.0-rc04'
+    xRunnerVer = '1.1.0-rc04'
+    xTestVer = '1.2.0'
+    xExtVer = '1.1.1'
 
     // Reactive Extensions
-    rxJava2Ver = '2.2.10'
+    rxJava2Ver = '2.2.12'
     rxAndroid2Ver = '2.1.1'
 
     // Billing Client
-    billingClientVer = '2.0.1'
+    billingClientVer = '2.0.3'
 
     // Developer-related
     timberVer = '4.7.1'
@@ -33,7 +37,7 @@ ext {
     mockitoVer = '2.28.2'
     mockitoKotlinVer = '2.1.0'
     jacocoVer = '0.1.2'
-    assertJVer = '3.9.0'
+    assertJVer = '3.9.1'
 
     // Dependencies
 
@@ -66,6 +70,9 @@ ext {
             mockito      : "org.mockito:mockito-core:$mockitoVer",
             mockitoKotlin: "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVer",
             assertJ      : "org.assertj:assertj-core:$assertJVer",
-            mockitoInline: "org.mockito:mockito-inline:$mockitoVer"
+            mockitoInline: "org.mockito:mockito-inline:$mockitoVer",
+            runner       : "androidx.test:runner:$xTestVer",
+            rules        : "androidx.test:rules:$xTestVer",
+            ext          : "androidx.test.ext:junit:$xExtVer"
     ]
 }

--- a/rxbilling/src/main/java/com/gen/rxbilling/flow/BuyItemRequest.kt
+++ b/rxbilling/src/main/java/com/gen/rxbilling/flow/BuyItemRequest.kt
@@ -5,5 +5,6 @@ import com.android.billingclient.api.BillingClient
 data class BuyItemRequest(
         @BillingClient.SkuType val type: String,
         val id: String,
-        val requestCode: Int
+        val requestCode: Int,
+        val developerPayload: String? = null
 )

--- a/rxbilling/src/main/java/com/gen/rxbilling/flow/ReplaceItemRequest.kt
+++ b/rxbilling/src/main/java/com/gen/rxbilling/flow/ReplaceItemRequest.kt
@@ -3,5 +3,6 @@ package com.gen.rxbilling.flow
 data class ReplaceItemRequest(
         val oldId: String,
         val newId: String,
-        val requestCode: Int
+        val requestCode: Int,
+        val developerPayload: String? = null
 )

--- a/rxbilling/src/main/java/com/gen/rxbilling/flow/RxBillingFlow.kt
+++ b/rxbilling/src/main/java/com/gen/rxbilling/flow/RxBillingFlow.kt
@@ -37,7 +37,7 @@ class RxBillingFlow(
                             context.packageName,
                             request.id,
                             request.type,
-                            /* developerPayload */ null)
+                            request.developerPayload)
                     val responseCode = BillingHelper.getResponseCodeFromBundle(buyIntentBundle, null)
                     val responseMessage = BillingHelper.getDebugMessageFromBundle(buyIntentBundle, null)
                     val billingResult = BillingResult.newBuilder()
@@ -65,7 +65,7 @@ class RxBillingFlow(
                             listOf(request.oldId),
                             request.newId,
                             BillingClient.SkuType.SUBS,
-                            /* developerPayload */ null
+                            request.developerPayload
 
                     )
                     val responseCode = BillingHelper.getResponseCodeFromBundle(buyIntentBundle, null)


### PR DESCRIPTION
`RxBillingFlow.buyItem` and `RxBillingFlow.replaceItem` accept a `BuyItemRequest` and `ReplaceItemRequest` but they don't accept a `developerPayload` attribute and pass it as `null`, which is not ok for whom supports `developerPayload` for internal validation